### PR TITLE
Fix: uneven spacing in About title

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -14,6 +14,8 @@
   </head>
   <body class="bg-gray-900 text-white min-h-screen flex flex-col">
     <main class="flex-grow max-w-5xl mx-auto px-6 py-16">
+      <!--added missing div to correct missing uneven spacing-->
+      <div class="flex items-center mb-10">
         <h1 class="text-5xl font-extrabold text-orange-400">
           About EventStack
         </h1>


### PR DESCRIPTION
Add missing div to correct uneven space in about Title.
closes #57 

### Screenshort (after fix)
<img width="1546" height="590" alt="aboutPage" src="https://github.com/user-attachments/assets/da083f40-a167-449e-9ab7-f19ac4279047" />


