### PR TITLE
Fix: Add Back to Events button on Event Details page (fixes #63)

### DIFF
--- a/templates/event.html
+++ b/templates/event.html
@@ -3,6 +3,21 @@
 {% block title %}{{ event['title'] }} - EventStack{% end %}
 
 {% block content %}
+
+<a href="{{ url_for('index') }}">
+  <button style="
+    background-color: #007bff;
+    color: white;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    margin-bottom: 20px;
+    cursor: pointer;
+  ">
+    ← Back to All Events
+  </button>
+</a>
+
 <div class="max-w-4xl mx-auto">
     <!-- Event Header -->
     <div class="bg-white rounded-lg shadow-md p-6 mb-6">


### PR DESCRIPTION
This pull request fixes [issue #63](https://github.com/abhirajadhikary06/eventstack/issues/63) by adding a "Back to All Events" button on the event details page.

The button helps improve navigation and UI/UX by allowing users to return to the main event listing easily.
